### PR TITLE
Fix/oxts lidar

### DIFF
--- a/oxts_ins/config/default.yaml
+++ b/oxts_ins/config/default.yaml
@@ -22,12 +22,10 @@ oxts_ins:
     pub_velocity_rate       : 100
     velocity_topic          : "velocity"
     velocity_vehicle_topic  : "velocity_vehicle"
-    velocity_lidar_topic    : "velocity_lidar"
     ### Publish Odometry message
     pub_odometry_rate       : 100
     odometry_topic          : "odometry"
     odometry_vehicle_topic  : "odometry_vehicle"
-    odometry_lidar_topic    : "odometry_lidar"
     ### Publish Path message
     pub_path_rate           : 100
     path_topic              : "path"
@@ -63,9 +61,10 @@ oxts_ins:
     ### Rotations in RPY order how to turn the unit to align with the vehicle
     ### This compensates for small differences in mounting of the lidar and vehicle.
     ### Assuming the lidar and unit is more aligned!
-    device2vehicle_roll       : 0.0 # [Deg]
-    device2vehicle_pitch      : 0.0 # [Deg]
-    device2vehicle_yaw        : -90.0 # [Deg]
-    device2vehicle_tolerance  : 5.0 # [Deg] # Use ISO RPY if difference is larger than this
-
-    
+    pub_lidar_flag          : false
+    velocity_lidar_topic    : "velocity_lidar"
+    odometry_lidar_topic    : "odometry_lidar"
+    device2vehicle_roll     : 0.0 # [Deg]
+    device2vehicle_pitch    : 0.0 # [Deg]
+    device2vehicle_yaw      : -90.0 # [Deg]
+    device2vehicle_tolerance: 5.0 # [Deg] # Use ISO RPY if difference is larger than this

--- a/oxts_ins/include/oxts_ins/convert.hpp
+++ b/oxts_ins/include/oxts_ins/convert.hpp
@@ -108,6 +108,8 @@ private:
   bool pub_imu_flag;
   /*! Flag to enable publishing of Tf messages. */
   bool pub_tf_flag;
+  /*! Flag to enable publishing of Lidar messages. */
+  bool pub_lidar_flag;
   /*! Publishing rate for lever arm message. */
   uint8_t pub_lever_arm_rate;
   /*! Publishing rate for IMU Bias message. */
@@ -264,11 +266,8 @@ public:
     velocity_topic = this->declare_parameter("velocity_topic", "velocity");
     velocity_vehicle_topic =
         this->declare_parameter("velocity_vehicle_topic", "velocity_vehicle");
-    velocity_lidar_topic =
-        this->declare_parameter("velocity_lidar_topic", "velocity_lidar");        
     odometry_topic = this->declare_parameter("odometry_topic", "odometry");
     odometry_vehicle_topic = this->declare_parameter("odometry_vehicle_topic", "odometry_vehicle");
-    odometry_lidar_topic = this->declare_parameter("odometry_lidar_topic", "odometry_lidar");
     path_topic = this->declare_parameter("path_topic", "path");
     time_reference_topic =
         this->declare_parameter("time_reference_topic", "time_reference");
@@ -279,6 +278,10 @@ public:
     imu_bias_topic = this->declare_parameter("imu_bias_topic", "imu_bias");
     imu_topic = this->declare_parameter("imu_topic", "imu");
 
+    pub_lidar_flag = this->declare_parameter("pub_lidar_flag", true);
+    velocity_lidar_topic =
+        this->declare_parameter("velocity_lidar_topic", "velocity_lidar");
+    odometry_lidar_topic = this->declare_parameter("odometry_lidar_topic", "odometry_lidar");
     device2vehicle_roll = this->declare_parameter("device2vehicle_roll", 0.0);
     device2vehicle_pitch = this->declare_parameter("device2vehicle_pitch", 0.0);
     device2vehicle_yaw = this->declare_parameter("device2vehicle_yaw", 0.0);
@@ -363,8 +366,10 @@ public:
       pubVelocityVehicle_ = this->create_publisher<geometry_msgs::msg::TwistStamped>(
           topic_prefix + "/" + velocity_vehicle_topic, 10);
 
-      pubVelocityLidar_ = this->create_publisher<geometry_msgs::msg::TwistStamped>(
-          topic_prefix + "/" + velocity_lidar_topic, 10);
+      if (pub_lidar_flag) {
+        pubVelocityLidar_ = this->create_publisher<geometry_msgs::msg::TwistStamped>(
+            topic_prefix + "/" + velocity_lidar_topic, 10);
+      }
     }
     if (pubOdometryInterval) {
       // Throw an error if ncom_rate / Odometry_rate is not an integer
@@ -380,8 +385,10 @@ public:
       pubOdometryVehicle_ = this->create_publisher<nav_msgs::msg::Odometry>(
           topic_prefix + "/" + odometry_vehicle_topic, 10);
 
-      pubOdometryLidar_ = this->create_publisher<nav_msgs::msg::Odometry>(
-          topic_prefix + "/" + odometry_lidar_topic, 10);
+      if (pub_lidar_flag) {
+        pubOdometryLidar_ = this->create_publisher<nav_msgs::msg::Odometry>(
+            topic_prefix + "/" + odometry_lidar_topic, 10);
+      }
     }
     if (pubPathInterval) {
       // Throw an error if ncom_rate / Path_rate is not an integer

--- a/oxts_ins/src/conversions/convert.cpp
+++ b/oxts_ins/src/conversions/convert.cpp
@@ -41,12 +41,16 @@ void OxtsIns::ncomCallbackRegular(const oxts_msgs::msg::Ncom::SharedPtr msg) {
     if (this->pubVelocityInterval && (sec_idx % this->pubVelocityInterval == 0)) {
       this->velocity(msg->header);
       this->velocity_vehicle(msg->header);
-      this->velocity_lidar(msg->header);
+      if (this->pub_lidar_flag){
+        this->velocity_lidar(msg->header);
+      }
     }
     if (this->pubOdometryInterval && (sec_idx % this->pubOdometryInterval == 0)) {
       this->odometry(msg->header);
       this->odometry_vehicle(msg->header);
-      this->odometry_lidar(msg->header);
+      if (this->pub_lidar_flag){
+        this->odometry_lidar(msg->header);
+      }
     }
     if (this->pubPathInterval && (sec_idx % this->pubPathInterval == 0)) {
       this->path(msg->header);
@@ -175,13 +179,13 @@ void OxtsIns::velocity(std_msgs::msg::Header header) {
 void OxtsIns::velocity_vehicle(std_msgs::msg::Header header) {
   header.frame_id = "oxts_link";
   auto msg = RosNComWrapper::velocity(this->nrx, header);
-  pubVelocity_->publish(msg);
+  pubVelocityVehicle_->publish(msg);
 }
 
 void OxtsIns::velocity_lidar(std_msgs::msg::Header header) {
   header.frame_id = "oxts_link";
   auto msg = RosNComWrapper::velocity_lidar(this->nrx, header, this->device2vehicle);
-  pubVelocityVehicle_->publish(msg);
+  pubVelocityLidar_->publish(msg);
 }
 
 void OxtsIns::odometry(std_msgs::msg::Header header) {

--- a/oxts_ins/src/conversions/wrapper.cpp
+++ b/oxts_ins/src/conversions/wrapper.cpp
@@ -307,28 +307,6 @@ geometry_msgs::msg::TwistStamped velocity_vehicle(const NComRxC *nrx,
                                           std_msgs::msg::Header head) {
   auto msg = geometry_msgs::msg::TwistStamped();
   msg.header = std::move(head);
-
-  // Construct vehicle-imu frame transformation --------------------------------
-
-  // auto veh_v = tf2::Vector3(nrx->mIsoVoX, nrx->mIsoVoY, nrx->mIsoVoZ);
-  // auto veh_w = tf2::Vector3(nrx->mIsoWoX, nrx->mIsoWoY, nrx->mIsoWoZ);
-  // auto imu_w = tf2::Vector3();
-  // auto imu_v = tf2::Vector3();
-  // auto q_iso_oxts = tf2::Quaternion();
-
-  // q_iso_oxts.setRPY(180.0 * NAV_CONST::DEG2RADS, 0.0, 0.0);
-  // auto r_iso_oxts = tf2::Matrix3x3(q_iso_oxts);
-
-  // imu_v = r_vat * r_iso_oxts * veh_v;
-  // imu_w = r_vat * veh_w;
-
-  // msg.twist.linear.x = imu_v.getX();
-  // msg.twist.linear.y = imu_v.getY();
-  // msg.twist.linear.z = imu_v.getZ();
-  // msg.twist.angular.x = imu_w.getX();
-  // msg.twist.angular.y = imu_w.getY();
-  // msg.twist.angular.z = imu_w.getZ();
-
   msg.twist.linear.x = nrx->mIsoVoX;
   msg.twist.linear.y = nrx->mIsoVoY;
   msg.twist.linear.z = nrx->mIsoVoZ;
@@ -373,25 +351,6 @@ geometry_msgs::msg::TwistStamped velocity_lidar(const NComRxC *nrx,
 
   return msg;
 }
-
-// geometry_msgs::msg::TwistStamped velocity_vehicle(const NComRxC *nrx,
-//                                                   std_msgs::msg::Header head) {
-//   auto msg = geometry_msgs::msg::TwistStamped();
-//   msg.header = std::move(head);
-
-//   auto veh_v = tf2::Vector3(nrx->mIsoVoX, nrx->mIsoVoY, nrx->mIsoVoZ);
-//   auto veh_w = tf2::Vector3(nrx->mIsoWoX, nrx->mIsoWoY, nrx->mIsoWoZ);
-  
-//   // std::cout << "veh_w = " << veh_w.getX() << ", " << veh_w.getY() << ", " << veh_w.getZ() << std::endl;
-//   msg.twist.linear.x = veh_v.getX();
-//   msg.twist.linear.y = veh_v.getY();
-//   msg.twist.linear.z = veh_v.getZ();
-//   msg.twist.angular.x = veh_w.getX(); 
-//   msg.twist.angular.y = veh_w.getY();
-//   msg.twist.angular.z = -veh_w.getZ(); //Wrong sign from NCOM??. TODO: check above
-
-//   return msg;
-// }
 
 tf2::Matrix3x3 getRotEnuToEcef(double lat0, double lon0) {
   double lambda = (lon0)*NAV_CONST::DEG2RADS;
@@ -505,15 +464,6 @@ nav_msgs::msg::Odometry odometry_vehicle(const NComRxC *nrx,
   msg.pose.pose.position.x = p_lrf.x();
   msg.pose.pose.position.y = p_lrf.y();
   msg.pose.pose.position.z = p_lrf.z();
-
-  // auto rpyIso = tf2::Quaternion();
-  // rpyIso.setRPY(nrx->mIsoRoll, nrx->mIsoPitch, nrx->mIsoYaw);
-
-  // msg.pose.pose.orientation.x = rpyIso.x();
-  // msg.pose.pose.orientation.y = rpyIso.y();
-  // msg.pose.pose.orientation.z = rpyIso.z();
-  // msg.pose.pose.orientation.w = rpyIso.w();
-
 
   auto rpyVehENU = RosNComWrapper::getIsoVehRPY(nrx);
   auto rpyVehLRF = tf2::Quaternion();


### PR DESCRIPTION
Fixed a bug when publishing lidar velocity (it would publish the lidar data on 'velocity_vehicle' instead) and cleaned up some unused code. Also added an option to disable publishing lidar and avoid warning messages for now configuring lidar specific parameters. Grouped all lidar config at the bottom of the default config file.