### PR TITLE
Added config option for status panel (ncom topic).

### DIFF
--- a/oxts_rviz_plugins/src/status_panel.cpp
+++ b/oxts_rviz_plugins/src/status_panel.cpp
@@ -23,6 +23,11 @@ void StatusPanel::save(rviz_common::Config config) const {
 
 void StatusPanel::load(const rviz_common::Config& conf) {
 	Panel::load(conf);
+	QString ncomTopic;
+	if (conf.mapGetString("ncomTopic", &ncomTopic)){
+		_widget->TopicEditor->setText(ncomTopic);
+		_widget->updateTopic();
+	}
 }
 
 void StatusPanel::onInitialize() {


### PR DESCRIPTION
Added option to config ncom topic in status panel. Used in Mondeo repo primarily where the prefix of the oxts driver is different.